### PR TITLE
Fix decoding code to treat unicode data correctly

### DIFF
--- a/pyjulius/core.py
+++ b/pyjulius/core.py
@@ -170,7 +170,7 @@ class Client(threading.Thread):
             data = readable[0].recv(1)
             if data == '\n':
                 break
-            line += unicode(data, self.encoding)
+            line += data
         return line
 
     def _readblock(self):

--- a/pyjulius/models.py
+++ b/pyjulius/models.py
@@ -91,6 +91,9 @@ class Word(object):
 
         """
         word = xml.get('WORD')
+        if isinstance(word, str):
+            # `get` returns `str` or `unicode`
+            word = word.decode(encoding)
         confidence = float(xml.get('CM'))
         return cls(word, confidence)
 

--- a/pyjulius/models.py
+++ b/pyjulius/models.py
@@ -90,12 +90,12 @@ class Word(object):
         :param string encoding: encoding of the xml
 
         """
-        word = unicode(xml.get('WORD'), encoding)
+        word = xml.get('WORD')
         confidence = float(xml.get('CM'))
         return cls(word, confidence)
 
     def __repr__(self):
-        return "<Word(%.2f, %s)>" % (self.confidence, self.word)
+        return "<Word(%.2f, %r)>" % (self.confidence, self.word)
 
     def __unicode__(self):
         return self.word.lower()


### PR DESCRIPTION
I fixed the code related to decoding.
- In `core.py`, when a double byte data comes, you cannot call `decode` for `data` because `data` only has one byte data.
- In `models.py` you cannot call `decode` for the result of `xml.get('WORD')` because this method returns `unicode`.